### PR TITLE
Release version 1.0.4

### DIFF
--- a/src/lib/Vay.ts
+++ b/src/lib/Vay.ts
@@ -238,7 +238,7 @@ export class Vay<T extends Dictionary<Record<string, Phrase>>> {
 
         const phrase = token.split('.').reduce((entry: any, token: string) => entry[token], phrases);
 
-        if (!phrase) {
+        if (phrase === undefined || phrase === null) {
             return exitWithError(VayError.NO_PHRASE);
         }
 

--- a/src/lib/VayError.ts
+++ b/src/lib/VayError.ts
@@ -2,7 +2,7 @@
 
 export enum VayError {
     NO_DICT = 'No dictionary found.',
-    NO_PHRASE = 'No phrase could be matched to token [{{phrase}}].',
+    NO_PHRASE = 'No phrase could be matched to token [{{token}}].',
     MALFORMED_PHRASE = 'The token [{{token}}] is not a valid Phrase containing only numeric keys to evaluate for plural forms.',
     MISSING_RENDER_TARGET = 'The target supplied to the `render` function is not a valid Element.',
 }


### PR DESCRIPTION
This PR resolves the following issues: 
- Empty translation strings seen as error.
- Warning for empty phrase not displaying token.